### PR TITLE
chore: migrate Upptime workflows to GitHub App token

### DIFF
--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -37,4 +37,3 @@ jobs:
           command: "response-time"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
-          SECRETS_CONTEXT: ${{ toJson(secrets) }}

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -27,45 +27,53 @@ jobs:
     name: Setup Upptime
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App write token
+        id: write-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.UPPTIME_APP_ID }}
+          private-key: ${{ secrets.UPPTIME_PRIVATE_KEY }}
+          permission-contents: write
+          permission-issues: write
+      - name: Generate App dispatch token
+        id: dispatch-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.UPPTIME_APP_ID }}
+          private-key: ${{ secrets.UPPTIME_PRIVATE_KEY }}
+          permission-actions: write
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GH_PAT || github.token }}
-      - name: Update template
-        uses: upptime/uptime-monitor@v1.41.3
-        with:
-          command: "update-template"
-        env:
-          GH_PAT: ${{ secrets.GH_PAT || github.token }}
+          token: ${{ steps.write-token.outputs.token }}
       - name: Update response time
         uses: upptime/uptime-monitor@v1.41.3
         with:
           command: "response-time"
         env:
-          GH_PAT: ${{ secrets.GH_PAT || github.token }}
-          SECRETS_CONTEXT: ${{ toJson(secrets) }}
+          GH_PAT: ${{ steps.write-token.outputs.token }}
       - name: Update summary in README
         uses: upptime/uptime-monitor@v1.41.3
         with:
           command: "readme"
         env:
-          GH_PAT: ${{ secrets.GH_PAT || github.token }}
+          GH_PAT: ${{ steps.write-token.outputs.token }}
       - name: Generate graphs
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: Graphs CI
-          token: ${{ secrets.GH_PAT || github.token }}
+          token: ${{ steps.dispatch-token.outputs.token }}
       - name: Generate site
         uses: upptime/uptime-monitor@v1.41.3
         with:
           command: "site"
         env:
-          GH_PAT: ${{ secrets.GH_PAT || github.token }}
+          GH_PAT: ${{ steps.write-token.outputs.token }}
       - uses: peaceiris/actions-gh-pages@v4
         name: GitHub Pages Deploy
         with:
-          github_token: ${{ secrets.GH_PAT || github.token }}
+          github_token: ${{ steps.write-token.outputs.token }}
           publish_dir: "site/status-page/__sapper__/export/"
           force_orphan: "false"
           user_name: "Upptime Bot"

--- a/.github/workflows/update-template.yml
+++ b/.github/workflows/update-template.yml
@@ -16,8 +16,6 @@
 
 name: Update Template CI
 on:
-  schedule:
-    - cron: "0 0 * * *"
   repository_dispatch:
     types: [update_template]
   workflow_dispatch:

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -26,12 +26,20 @@ jobs:
     name: Deploy updates
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App write token
+        id: write-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.UPPTIME_APP_ID }}
+          private-key: ${{ secrets.UPPTIME_PRIVATE_KEY }}
+          permission-contents: write
+          permission-issues: write
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GH_PAT || github.token }}
+          token: ${{ steps.write-token.outputs.token }}
       - name: Update code
         uses: upptime/updates@master
         env:
-          GH_PAT: ${{ secrets.GH_PAT || github.token }}
+          GH_PAT: ${{ steps.write-token.outputs.token }}

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -37,4 +37,3 @@ jobs:
           command: "update"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
-          SECRETS_CONTEXT: ${{ toJson(secrets) }}


### PR DESCRIPTION
## Summary

Replace the `alpacax-gh-bot` fine-grained PAT (`UPPTIME_STATUS_TOKEN`) with the `alpacax-upptime` GitHub App token across the Upptime workflows that genuinely need elevated permissions. This mirrors the change applied to [`alpacon-status-dev` PR #28](https://github.com/alpacax/alpacon-status-dev/pull/28) and verified there for ~17 hours of schedule runs without a single failure.

## Changes

### `.github/workflows/setup.yml`
- Add two scoped App token steps via `actions/create-github-app-token@v2`:
  - `write-token` — `permission-contents: write`, `permission-issues: write` (Upptime commands + gh-pages deploy).
  - `dispatch-token` — `permission-actions: write` (only for the `Generate graphs` workflow-dispatch step).
- Replace all `${{ secrets.GH_PAT || github.token }}` references with the appropriate scoped token per step.
- Remove the `Update template` step so Setup CI no longer regenerates the patched workflows.
- Drop `SECRETS_CONTEXT: ${{ toJson(secrets) }}` from the `Update response time` step.

### `.github/workflows/updates.yml`
- Add `write-token` step (`permission-contents: write` + `permission-issues: write` only — no `actions:write`).
- Replace checkout token and `GH_PAT` env with the scoped App token.

### `.github/workflows/uptime.yml`
- Drop `SECRETS_CONTEXT: ${{ toJson(secrets) }}` from the `Check endpoint status` step.

### `.github/workflows/response-time.yml`
- Drop `SECRETS_CONTEXT: ${{ toJson(secrets) }}` from the `Update response time` step (daily cron, same exposure risk).

### `.github/workflows/update-template.yml`
- Remove the `schedule: cron "0 0 * * *"` trigger to prevent automatic template sync from overwriting the patched workflows above. `workflow_dispatch` is preserved for the documented quarterly manual sync.
- Workflow still uses `${{ secrets.GH_PAT || github.token }}`; once `GH_PAT` is retired this falls back to `github.token`, which is sufficient for this repo since it does not have a ruleset that restricts workflow-file writes.

## Notes

- The remaining Upptime workflows (`graphs`, `summary`, `site`) still use `${{ secrets.GH_PAT || github.token }}` and will fall back to `github.token` once `GH_PAT` is removed — sufficient for self-repo commits and gh-pages deploy.
- Org-level secrets `UPPTIME_APP_ID` / `UPPTIME_PRIVATE_KEY` are already scoped to `alpacon-status` and `alpacon-status-dev`.
- The `alpacax-upptime` GitHub App is already installed on this repo with `contents:write`, `issues:write`, `actions:write`, `metadata:read`.

## Test plan

- [ ] After merge, confirm the next `Uptime CI` cron (within 5 minutes) succeeds.
- [ ] Manually trigger `Setup CI` and verify all steps complete: Generate App write token → Generate App dispatch token → Checkout → Update response time → Update summary in README → Generate graphs (workflow-dispatch) → Generate site → GitHub Pages Deploy. Note: the `Update template` step is intentionally absent.
- [ ] Manually trigger `Updates CI` and verify the dependency update step completes.
- [ ] After verification, remove the `GH_PAT` repository secret.
- [ ] After 24h of stable runs, revoke the `UPPTIME_STATUS_TOKEN` fine-grained PAT on the `alpacax-gh-bot` account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)